### PR TITLE
Fix missing subdependency of com.google.android.libraries.maps

### DIFF
--- a/src/android/frameworks/pgm-custom.gradle
+++ b/src/android/frameworks/pgm-custom.gradle
@@ -155,6 +155,7 @@ android {
 
     dependencies {
       implementation 'com.google.android.libraries.maps:maps:3.1.0-beta'
+      implementation 'com.android.volley:volley:1.2.0' // Fix missing subdependency of 'com.google.android.libraries.maps:maps:3.1.0-beta'
       implementation 'com.android.support:multidex:1.0.3'
     }
 


### PR DESCRIPTION
`com.google.android.libraries.maps` package has `com.android.volley:volley:1.1.1` as dependency.
That dependency lived in JCenter repository, [that has been turned off definitely on August 15th, 2024](https://jfrog.com/blog/jcenter-sunset/)

Google tried to upload 1.1.1 version to Google Maven and Maven Central repositories but no was possible so directly uploaded following version (1.2.0) which should be backwards compatible